### PR TITLE
Standardize import statement to k8s.io/client

### DIFF
--- a/examples/create-pod/main.go
+++ b/examples/create-pod/main.go
@@ -20,8 +20,8 @@ package main
 import (
 	"context"
 
-	"github.com/kubernetes-client/go/kubernetes/client"
-	"github.com/kubernetes-client/go/kubernetes/config"
+	"k8s.io/client/kubernetes/client"
+	"k8s.io/client/kubernetes/config"
 )
 
 func main() {

--- a/examples/informer/informer.go
+++ b/examples/informer/informer.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-client/go/kubernetes/client"
-	"github.com/kubernetes-client/go/kubernetes/config"
+	"k8s.io/client/kubernetes/client"
+	"k8s.io/client/kubernetes/config"
 )
 
 type handler struct{}

--- a/examples/out-of-cluster-client-configuration/main.go
+++ b/examples/out-of-cluster-client-configuration/main.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-client/go/kubernetes/client"
-	"github.com/kubernetes-client/go/kubernetes/config"
+	"k8s.io/client/kubernetes/client"
+	"k8s.io/client/kubernetes/config"
 )
 
 func main() {

--- a/examples/watch/watch.go
+++ b/examples/watch/watch.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubernetes-client/go/kubernetes/client"
-	"github.com/kubernetes-client/go/kubernetes/config"
+	"k8s.io/client/kubernetes/client"
+	"k8s.io/client/kubernetes/config"
 )
 
 func main() {

--- a/kubernetes/config/incluster_config.go
+++ b/kubernetes/config/incluster_config.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/kubernetes-client/go/kubernetes/client"
+	"k8s.io/client/kubernetes/client"
 )
 
 const (

--- a/kubernetes/config/kube_config.go
+++ b/kubernetes/config/kube_config.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/kubernetes-client/go/kubernetes/client"
-	"github.com/kubernetes-client/go/kubernetes/config/api"
+	"k8s.io/client/kubernetes/client"
+	"k8s.io/client/kubernetes/config/api"
 )
 
 const (

--- a/kubernetes/config/util.go
+++ b/kubernetes/config/util.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kubernetes-client/go/kubernetes/config/api"
+	"k8s.io/client/kubernetes/config/api"
 )
 
 // DataOrFile reads content of data, or file's content if data doesn't exist


### PR DESCRIPTION
To standardize the import statement as `k8s.io/client` (same as mentioned in Readme.md)


While trying to use this repo in other project https://github.com/dapr/components-contrib/issues/62, I am facing the below issue

```
go: github.com/kubernetes-client/go@v0.0.0-20190928040339-c757968c4c36 used for two different module paths (github.com/kubernetes-client/go and k8s.io/client)
```

This is related to https://github.com/golang/go/issues/26904, which is currently planned for go 1.15.