### PR TITLE
Fix compilation error

### DIFF
--- a/kubernetes/config/azure.go
+++ b/kubernetes/config/azure.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -60,8 +61,8 @@ func (l *KubeConfigLoader) refreshAzureToken() error {
 	token := adal.Token{
 		AccessToken:  l.user.AuthProvider.Config["access-token"],
 		RefreshToken: l.user.AuthProvider.Config["refresh-token"],
-		ExpiresIn:    l.user.AuthProvider.Config["expires-in"],
-		ExpiresOn:    l.user.AuthProvider.Config["expires-on"],
+		ExpiresIn:    json.Number(l.user.AuthProvider.Config["expires-in"]),
+		ExpiresOn:    json.Number(l.user.AuthProvider.Config["expires-on"]),
 	}
 	sptToken, err := adal.NewServicePrincipalTokenFromManualToken(*config, clientID, resource, token)
 	if err := sptToken.Refresh(); err != nil {


### PR DESCRIPTION
It fixes following build error:
```
vendor/github.com/kubernetes-client/go/kubernetes/config/azure.go:63:3: cannot use l.user.AuthProvider.Config["expires-in"] (type string) as type json.Number in field value
vendor/github.com/kubernetes-client/go/kubernetes/config/azure.go:64:3: cannot use l.user.AuthProvider.Config["expires-on"] (type string) as type json.Number in field value```